### PR TITLE
Protocol

### DIFF
--- a/assets/js/vue/Dashboard.vue
+++ b/assets/js/vue/Dashboard.vue
@@ -3,14 +3,16 @@
     <loading-indicator :spin="!constructionSite">
       <div class="row">
         <div class="col-md-12 col-lg-4">
+          <h3>{{ $t('construction_site._name')}}</h3>
           <dashboard-construction-site :construction-site="constructionSite" />
-          <hr />
         </div>
         <div class="col-md-6 col-lg-4">
+          <h3>{{ $t('issue._plural')}}</h3>
           <dashboard-issues-summary class="shadow mb-4" :construction-site="constructionSite" />
           <dashboard-issues-graph class="shadow" :construction-site="constructionSite" />
         </div>
         <div class="col-md-6 col-lg-4">
+          <h3>{{ $t('dashboard.activity')}}</h3>
           <dashboard-feed class="shadow" :construction-site="constructionSite" />
         </div>
       </div>

--- a/assets/js/vue/Dashboard.vue
+++ b/assets/js/vue/Dashboard.vue
@@ -1,19 +1,24 @@
 <template>
   <div id="dashboard">
-    <loading-indicator :spin="!constructionSite">
+    <loading-indicator :spin="!constructionSite || !constructionManagers">
       <div class="row">
         <div class="col-md-12 col-lg-4">
-          <h3>{{ $t('construction_site._name')}}</h3>
-          <dashboard-construction-site :construction-site="constructionSite" />
+          <h3>{{ $t('construction_site._name') }}</h3>
+          <dashboard-construction-site class="shadow mb-4" :construction-site="constructionSite"/>
+          <dashboard-protocol
+              class="shadow"
+              :construction-managers="constructionManagers" :construction-site="constructionSite"
+              :construction-manager-iri="constructionManagerIri"/>
         </div>
         <div class="col-md-6 col-lg-4">
-          <h3>{{ $t('issue._plural')}}</h3>
-          <dashboard-issues-summary class="shadow mb-4" :construction-site="constructionSite" />
-          <dashboard-issues-graph class="shadow" :construction-site="constructionSite" />
+          <h3>{{ $t('issue._plural') }}</h3>
+          <dashboard-issues-summary class="shadow mb-4" :construction-site="constructionSite"/>
+          <dashboard-issues-graph class="shadow" :construction-site="constructionSite"/>
         </div>
         <div class="col-md-6 col-lg-4">
-          <h3>{{ $t('dashboard.activity')}}</h3>
-          <dashboard-feed class="shadow" :construction-site="constructionSite" />
+          <h3>{{ $t('dashboard.activity') }}</h3>
+          <dashboard-feed class="shadow" :construction-site="constructionSite"
+                          :construction-managers="constructionManagers"/>
         </div>
       </div>
     </loading-indicator>
@@ -21,16 +26,18 @@
 </template>
 
 <script>
-import { api } from './services/api'
+import {api} from './services/api'
 import DashboardConstructionSite from './components/DashboardConstructionSite'
 import DashboardIssuesGraph from './components/DashboardIssuesGraph'
 import DashboardIssuesSummary from './components/DashboardIssuesSummary'
 import DashboardFeed from './components/DashboardFeed'
 import LoadingIndicator from './components/Library/View/LoadingIndicator'
 import AtomSpinner from './components/Library/View/Base/AtomSpinner'
+import DashboardProtocol from "./components/DashboardProtocol.vue";
 
 export default {
   components: {
+    DashboardProtocol,
     AtomSpinner,
     LoadingIndicator,
     DashboardFeed,
@@ -38,17 +45,23 @@ export default {
     DashboardIssuesSummary,
     DashboardConstructionSite
   },
-  data () {
+  data() {
     return {
+      constructionManagerIri: null,
       constructionSite: null,
+      constructionManagers: null,
     }
   },
-  mounted () {
+  mounted() {
     api.setupErrorNotifications(this.$t)
     api.authenticate()
-        .then(_ => {
+        .then(me => {
+              this.constructionManagerIri = me.constructionManagerIri
               api.getConstructionSite()
-                  .then(constructionSite => { this.constructionSite = constructionSite })
+                  .then(constructionSite => this.constructionSite = constructionSite)
+
+              api.getConstructionManagers(this.constructionSite)
+                  .then(constructionManagers => this.constructionManagers = constructionManagers)
             }
         )
   }

--- a/assets/js/vue/components/DashboardProtocol.vue
+++ b/assets/js/vue/components/DashboardProtocol.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="card">
+    <div class="card-body limited-height">
+      <div class="loading-center" v-if="constructionSiteProtocolEntries === null">
+        <loading-indicator-secondary />
+      </div>
+      <construction-site-timeline
+          v-else
+          :construction-site="constructionSite"
+          :construction-managers="constructionManagers" :authority-iri="constructionManagerIri"
+          :protocol-entries="constructionSiteProtocolEntries"/>
+    </div>
+  </div>
+</template>
+
+<script>
+
+import ConstructionSiteTimeline from "./View/ConstructionSiteTimeline.vue";
+import LoadingIndicatorSecondary from "./Library/View/LoadingIndicatorSecondary.vue";
+import {api} from "../services/api";
+
+export default {
+  components: {
+    LoadingIndicatorSecondary,
+    ConstructionSiteTimeline,
+  },
+  data() {
+    return {
+      newProtocolEntries: [],
+      constructionSiteProtocolEntries: null,
+    }
+  },
+  props: {
+    constructionSite: {
+      type: Object,
+      required: true
+    },
+    constructionManagers: {
+      type: Array,
+      required: true
+    },
+    constructionManagerIri: {
+      type: String,
+      required: false
+    },
+  },
+  mounted() {
+    api.getProtocolEntries(this.constructionSite, this.constructionSite)
+        .then(entries => {
+          this.constructionSiteProtocolEntries = entries
+        })
+  }
+}
+</script>
+
+<style scoped>
+.limited-height {
+  max-height: 30em;
+  overflow-x: scroll;
+}
+
+</style>

--- a/assets/js/vue/components/View/ConstructionSiteTimeline.vue
+++ b/assets/js/vue/components/View/ConstructionSiteTimeline.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="row mb-2">
+    <div class="col-3">
+      {{ $t('protocol_entry._plural_short') }}
+    </div>
+    <div class="col">
+      <add-protocol-entry-button
+          :authority-iri="authorityIri" :root="constructionSite"
+          :construction-site="constructionSite"
+          @added="newProtocolEntries.push($event)"/>
+    </div>
+  </div>
+
+  <protocol-entry v-for="(entry, index) in orderedProtocolEntries" :id="entry['@id']"
+                  :last="index+1 === orderedProtocolEntries.length"
+                  :protocol-entry="entry"
+                  :root="constructionSite"
+                  :is-removable="newProtocolEntries.includes(entry)"
+                  :created-by="responsiblesLookup[entry['createdBy']]"
+  />
+</template>
+
+<script>
+
+import {api, iriToId} from "../../services/api";
+import ProtocolEntry from "./ProtocolEntry.vue";
+import LoadingIndicatorSecondary from "../Library/View/LoadingIndicatorSecondary.vue";
+import AddProtocolEntryButton from "../Action/AddProtocolEntryButton.vue";
+
+export default {
+  components: {
+    AddProtocolEntryButton,
+    LoadingIndicatorSecondary,
+    ProtocolEntry,
+  },
+  data() {
+    return {
+      newProtocolEntries: [],
+    }
+  },
+  props: {
+    constructionSite: {
+      type: Object,
+      required: true
+    },
+    constructionManagers: {
+      type: Array,
+      required: true
+    },
+    protocolEntries: {
+      type: Array,
+      required: true
+    },
+    authorityIri: {
+      type: String,
+      required: false
+    },
+  },
+  computed: {
+    responsiblesLookup: function () {
+      let responsiblesLookup = {}
+      this.constructionManagers.forEach(cm => responsiblesLookup[iriToId(cm['@id'])] = cm)
+
+      return responsiblesLookup
+    },
+    orderedProtocolEntries: function () {
+      const protocolEntries = [...this.newProtocolEntries, ...(this.protocolEntries ?? [])]
+          .filter(entry => !entry.isDeleted)
+      protocolEntries.sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+      return protocolEntries
+    }
+  },
+}
+</script>

--- a/assets/js/vue/components/View/ConstructionSiteView.vue
+++ b/assets/js/vue/components/View/ConstructionSiteView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="card shadow">
+  <div class="card">
     <img class="card-img-top max-heighted" v-if="constructionSite.imageUrl" :src="constructionSite.imageUrl + '?size=full'"
          :alt="'image of ' + constructionSite.name">
     <div class="card-body">

--- a/assets/js/vue/components/View/ConstructionSiteView.vue
+++ b/assets/js/vue/components/View/ConstructionSiteView.vue
@@ -1,11 +1,13 @@
 <template>
-  <div>
-    <img class="img-fluid shadow" v-if="constructionSite.imageUrl" :src="constructionSite.imageUrl + '?size=full'"
+  <div class="card shadow">
+    <img class="card-img-top max-heighted" v-if="constructionSite.imageUrl" :src="constructionSite.imageUrl + '?size=full'"
          :alt="'image of ' + constructionSite.name">
-    <h4 class="mt-3">{{ constructionSite.name }}</h4>
-    <p>
-      <span class="pre">{{ address.join("\n") }}</span>
-    </p>
+    <div class="card-body">
+      <h5 class="card-title">{{ constructionSite.name }}</h5>
+      <p class="card-text">
+        <span class="pre">{{ address.join("\n") }}</span>
+      </p>
+    </div>
   </div>
 </template>
 
@@ -27,3 +29,10 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.max-heighted {
+  max-height: 20em;
+  object-fit: cover;
+}
+</style>

--- a/assets/js/vue/components/View/CraftsmanTimeline.vue
+++ b/assets/js/vue/components/View/CraftsmanTimeline.vue
@@ -1,6 +1,6 @@
 <template>
   <loading-indicator-secondary :spin="craftsmanProtocolEntries === null">
-    <div class="row mb-3">
+    <div class="row mb-2">
       <div class="col-3">
         {{ $t('protocol_entry._plural_short') }}
       </div>

--- a/assets/js/vue/components/View/IssueTimeline.vue
+++ b/assets/js/vue/components/View/IssueTimeline.vue
@@ -1,6 +1,6 @@
 <template>
   <loading-indicator-secondary :spin="issueProtocolEntries === null">
-    <div class="row">
+    <div class="row mb-2">
       <div class="col-3">
         {{ $t('protocol_entry._plural_short') }}
       </div>

--- a/assets/js/vue/components/View/ProtocolEntry.vue
+++ b/assets/js/vue/components/View/ProtocolEntry.vue
@@ -26,7 +26,8 @@
           </p>
         </div>
         <p v-else-if="protocolEntry.type === 'FILE'" class="mb-0">
-          {{ protocolEntry.payload }}&nbsp;
+          {{ protocolEntry.payload }}
+          <span v-if="protocolEntry.payload">&nbsp;</span>
           <a :href="protocolEntry.fileUrl" download>
             <font-awesome-icon :icon="['far', 'down']"/>
             {{ $t('_view.download') }}

--- a/assets/js/vue/localization/de.json
+++ b/assets/js/vue/localization/de.json
@@ -293,6 +293,7 @@
   },
   "dashboard": {
     "feed": "Feed",
+    "activity": "Aktivität",
     "new_issues_in_foyer": "Eine neue Pendenz erfasst. | {count} neue Pendenzen erfasst."
   },
   "edit": {


### PR DESCRIPTION
To finish up the protocol feature, consider the following open TODOs.

Usability:
- [ ] The empty protocol looks weird, both on craftsman / construction site. Add a help alert there?
- [ ] Customer feedback indicates craftsman protocol is useful to see within the issues protocol. However, holistic solution to integrate next higher context into the protocol (issues integrates CS and craftsman, craftsman integrates CS) seems to not work well. How to consiliate?
- [ ] Customer usage implies that last protocol entry useful to see in overviews. However, difficult to implement / visualize. Is this really necessary?
- [ ] The feed on the dashboard is probably not useful in the state it is now.
- [ ] The "Last activity" checkbox in the issues table excludes protocol activity, which might be surprising.

Technical:
- [ ] The UI architecture was compromised; in the 'View' folder, now also API requests are done.
- [ ] Translations are not yet done
